### PR TITLE
Fix a few weird monitoring errors

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -123,9 +123,6 @@ monitors:
     options:
       notify_no_data: true
       require_full_window: true
-      thresholds:
-        critical: 1.0
-        warning: 1.0
     query: min(last_5m):avg:gearman.workers_by_task{host:zuul,task:merger:merge} < 1
     type: metric alert
 
@@ -196,5 +193,5 @@ monitors:
       thresholds:
         critical: 100000000
         warning: 400000000
-    query: avg:system.mem.free{*} by {host}
+    query: avg(last_5m):avg:system.mem.free{*} by {host} < 100000000
     type: metric alert


### PR DESCRIPTION
Apparently a few of our monitors had incompatible options that caused
"400 Client Error" when datadog-builder runs. I've attempted to strip
these incompatible options off. I believe the monitors do the same
thing still.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>