### PR TITLE
Remove the mysql ansible check

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -30,21 +30,6 @@ monitors:
     type: service check
 
   - message: |
-      mysql is down
-
-      @slack-pirateshiprevenge
-    name: mysqld process from ansible
-    multi: true
-    options:
-      notify_no_data: false
-      thresholds:
-        critical: 1
-        ok: 1
-        warning: 1
-    query: '"process.up".over("host:zuul","process:mysql").by("host","process").last(2).count_by_status()'
-    type: service check
-
-  - message: |
       Gearman went down!
 
       {{#is_alert}}


### PR DESCRIPTION
This check used to be created by the ansible modules and was a really
basic way of enforcing that the mysql process was running. Since then
we've done integrations and other things that can test the process
running much more effectively.

Remove the old check.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>