### PR TITLE
remove logs host from OOM monitor

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -178,7 +178,7 @@ monitors:
       thresholds:
         critical: 100000000
         warning: 400000000
-    query: avg(last_5m):avg:system.mem.usable{*} by {host} < 100000000
+    query: avg(last_5m):avg:system.mem.usable{!host:logs} by {host} < 100000000
     type: metric alert
 
   - message: |


### PR DESCRIPTION
the OOM monitor is spamming our slack channel; the levels associated with the monitor are not appropriate for the 'logs' host.  this commit removes 'logs' - a follow up commit will add an appropriate monitor