### PR TITLE
Add used nodes to nodepool monitor

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -208,5 +208,5 @@ monitors:
       thresholds:
         critical: 1
         warning: 3
-    query: avg:nodepool.nodes.ready{host:nodepool} < 2
+    query: avg:nodepool.nodes.ready{host:nodepool} + avg:nodepool.nodes.used{host:nodepool} < 2
     type: metric alert


### PR DESCRIPTION
We want to alert when we have no ready or used nodes, which would
imply that nodes are going directly from building to deleting.
Only querying ready nodes will give false positives during the period
of time after ready nodes become used and new nodes are still building.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>