### PR TITLE
Add monitor for nodepool_server.got_images

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -195,9 +195,10 @@ monitors:
         warning: 400000
     query: avg:zuul.pipeline.check_github.job.bonnyci_run_check.wait_time.max{host:zuul} > 800000
     type: metric alert
+
   - message: |
-      {{#is_warning}}Only {{warn_threshold}} nodes available{{/is_warning}} 
-      {{#is_alert}} {{threshold}} nodes available!{{/is_alert}} 
+      {{#is_warning}}Only {{warn_threshold}} nodes available{{/is_warning}}
+      {{#is_alert}} {{threshold}} nodes available!{{/is_alert}}
 
       @slack-bonny-dd-alerts
     multi: false
@@ -226,3 +227,19 @@ monitors:
         critical: 2
     query: '"apache.can_connect".over("*").by("host","port","server").last(3).count_by_status()'
     type: service check
+
+  - message: |
+      {{#is_alert}}Nodepool image age is very high{{/is_alert}}
+      {{#is_warning}}Nodepool image age is high{{/is_warning}}
+
+      @slack-bonny-dd-alerts
+    multi: false
+    name: Stale Images
+    options:
+      notify_no_data: false
+      require_full_window: false
+      thresholds:
+        critical: 345600
+        warning: 172800
+    query: '"nodepool_server.got_images".over("host:nodepool")'
+    type: metric alert


### PR DESCRIPTION
Now that we have a check for stale nodepool images, we should monitor
this check and warn/alert on two day increments.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>