### PR TITLE
remove reference to logs host

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -172,7 +172,7 @@ monitors:
       thresholds:
         critical: 100000000
         warning: 400000000
-    query: avg(last_5m):avg:system.mem.usable{!host:logs} by {host} < 100000000
+    query: avg(last_5m):avg:system.mem.usable{*} by {host} < 100000000
     type: metric alert
 
   - message: |


### PR DESCRIPTION
the host 'logs' no longer exists - remove it from being referenced in monitors