### PR TITLE
Add bonnyci test hook

### DIFF
--- a/.bonnyci/run.sh
+++ b/.bonnyci/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+venv_dir=$(mktemp -d)
+trap 'rm -rf $venv_dir' EXIT
+
+virtualenv "$venv_dir"
+# shellcheck disable=1090
+source "$venv_dir"/bin/activate
+
+# Install all requirements for tests to run
+if test -r test-requirements.txt; then
+    pip install -r test-requirements.txt
+fi
+
+if test -r requirements.txt; then
+    pip install -r requirements.txt
+fi
+
+if test -r requirements.yml; then
+    ansible-galaxy install -r install -r requirements.yml
+fi
+
+run-parts --verbose --exit-on-error --regex '^test.*$' tests/

--- a/tests/test-dd-builder-validation.sh
+++ b/tests/test-dd-builder-validation.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+echo -n "Testing monitor validation via datadog-builder"
+
+if ! datadog-builder validate monitors.yml; then
+  echo "ERROR! :("
+  exit 1
+fi
+
+echo "OK! :)"


### PR DESCRIPTION
datadog-monitors is added to bonnyci, but there's no tests to run. This
installs datadog-builder and runs the validator on the monitors.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>