### PR TITLE
a few monitor fixes

### DIFF
--- a/monitors.yml
+++ b/monitors.yml
@@ -214,7 +214,7 @@ monitors:
       thresholds:
         critical: 800000
         warning: 400000
-    query: avg:zuul.pipeline.check_github.job.bonnyci_run_check.wait_time.max{host:zuul} > 800000
+    query: avg:zuul.pipeline.gerrithub_check.resident_time.max{host:zuul} > 800000
     type: metric alert
 
   - message: |
@@ -234,7 +234,7 @@ monitors:
       thresholds:
         critical: 2
         warning: 4
-    query: avg:nodepool.nodes.ready{host:nodepool} + avg:nodepool.nodes.used{host:nodepool} < 2
+    query: 'avg:nodepool.nodes.ready{host:nodepool} + avg:nodepool.nodes.used{host:nodepool} < 2'
     type: metric alert
 
   - message: |


### PR DESCRIPTION
a few of our monitors are failing in datadog-builder with the error:
ERROR:datadog_builder.update:Response body: {"errors":["The value provided for parameter 'query' is invalid"]}

fix that